### PR TITLE
multiprocessing fix and helper func

### DIFF
--- a/fuse/utils/multiprocessing/__init__.py
+++ b/fuse/utils/multiprocessing/__init__.py
@@ -1,1 +1,2 @@
 from .run_multiprocessed import run_multiprocessed, get_from_global_storage
+from .helpers import get_chunks_ranges

--- a/fuse/utils/multiprocessing/helpers.py
+++ b/fuse/utils/multiprocessing/helpers.py
@@ -1,0 +1,21 @@
+import numpy as np
+from typing import List, Tuple
+
+def get_chunks_ranges(total:int, chunk_size:int) -> List[Tuple[int,int]]:
+    '''
+    Creates "chunks" of work, useful when creating worker functions for run_multiprocessed 
+     where each workers gets a range ("chunk") to work on.
+
+    Returns a list of tuples [start_index, end_index)    
+
+    for example: get_chunks_ranges(10, 3) would return [(0,3), (3,6), (6,9), (9,10)] 
+    '''
+
+    if chunk_size >= total:
+        return [(0,total)]
+
+    steps = np.arange(0, total, chunk_size)
+    ans = list(zip(steps[:-1], steps[1:]))
+    if ans[-1][-1] < total:
+        ans.append((ans[-1][-1], total))
+    return ans

--- a/fuse/utils/multiprocessing/run_multiprocessed.py
+++ b/fuse/utils/multiprocessing/run_multiprocessed.py
@@ -67,7 +67,7 @@ def __orig__run_multiprocessed(worker_func, args_list, workers=0, verbose=0,
         with mp.Pool(processes=workers, initializer=_store_in_global_storage, initargs=(copy_to_global_storage,), maxtasksperchild=400) as pool:
             if verbose>0:
                 cprint(f'multiprocess pool created with {workers} workers.', 'cyan')            
-            map_func = pool.imap if keep_results_order else pool.iunordered
+            map_func = pool.imap if keep_results_order else pool.imap_unordered
             for curr_ans in tqdm_func(map_func(
                     worker_func,
                     args_list), total=len(args_list), smoothing=0.1, disable=verbose<1):


### PR DESCRIPTION
Multiprocessing:

1. Fixed imap_unordered usage for the case that you don't care about the ordered of returned answers
3. Added a utility function which is useful for creating shards/chunks of works for multiprocessing workers